### PR TITLE
vegan::adonis is deprecated, will be defunct: use vegan::adonis2

### DIFF
--- a/demo/mefa.R
+++ b/demo/mefa.R
@@ -205,7 +205,7 @@ wait()
 
 if (require(vegan)) {
 m6 <- m2[summary(m2)$s.abu != 0, , ]
-m6.ado <- adonis(m6$xtab ~ .^2,
+m6.ado <- adonis2(m6$xtab ~ .^2,
     data = m6$samp, permutations = 100)
 m6.ado
 }


### PR DESCRIPTION
Peter, vegan 2.6-6 (CRAN) deprecated adonis in favour of adonis2, and next major-ish release (2.7-0) will make it defunct. This would break mefa and give an error. Fix is small, but necessary. adonis2 has been the recommended method since vegan 2.6-2 and this fix will work also with older vegan versions.